### PR TITLE
Adds note to installation on the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Optional tools (for external converters):
 
 Run `python setup.py install` as root.
 
+If you get this error : 
+ `Traceback (most recent call last):
+   File "setup.py", line 11, in <module>
+     from setuptools import setup
+ ImportError: No module named setuptools`
+
+Run `apt-get install python-setuptools` as root then try again.
+
 ## Contributing
 
 MUP is managed using the [lightweight project management policy][lpmp].


### PR DESCRIPTION
Adds a fix for `ImportError: No module named setuptools` when trying to install on a fresh install of Ubuntu Gnome 14.10 distro. It complains about not having a module called setuptools.

This is fixed installing such tools with the command: `apt-get install python-setuptools` as root.
