### PR TITLE
disable context menu

### DIFF
--- a/mup/view.py
+++ b/mup/view.py
@@ -30,6 +30,7 @@ class View(QWidget):
 
     def _setupView(self):
         self._view = QWebView(self)
+        self._view.contextMenuEvent = lambda e : None
         page = QWebPage()
         page.setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
         page.linkClicked.connect(self._openUrl)


### PR DESCRIPTION
The context menu proposed by default is broken:
- reload broke the page layout
- some option like "Open in new window" doesn't make sense here and are not
  implemented
- The useful only option is "copy", but it can be done with OS shortcut

A proper context menu can be implemented later but in the meantime, it is
better to disable it.

This patch use shameless monkey patching
