### PR TITLE
implement basic context menu

### DIFF
--- a/mup/view.py
+++ b/mup/view.py
@@ -12,6 +12,7 @@ from .converterthread import ConverterThread
 class View(QWidget):
     internalUrlClicked = pyqtSignal(QUrl)
     loadRequested = pyqtSignal(str)
+    reloadRequested = pyqtSignal()
 
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
@@ -30,6 +31,9 @@ class View(QWidget):
 
     def _setupView(self):
         self._view = QWebView(self)
+        self._view.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._view.customContextMenuRequested.connect(
+            self._onCustomContextMenuRequested)
         page = QWebPage()
         page.setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
         page.linkClicked.connect(self._openUrl)
@@ -52,6 +56,17 @@ class View(QWidget):
         self._linkLabelHideTimer.setSingleShot(True)
         self._linkLabelHideTimer.setInterval(250)
         self._linkLabelHideTimer.timeout.connect(self._linkLabel.hide)
+
+    def _onCustomContextMenuRequested(self, ev):
+        menu = QMenu(self)
+
+        menu.addAction(self._view.pageAction(QWebPage.Copy))
+
+        action = menu.addAction(
+            QCoreApplication.translate("Window", "Force Reload"))
+        action.triggered.connect(self.reloadRequested)
+
+        menu.exec(self.mapToGlobal(ev))
 
     def load(self, filename, converter, lastScrollPos=None):
         self._lastScrollPos = lastScrollPos

--- a/mup/window.py
+++ b/mup/window.py
@@ -132,6 +132,7 @@ class Window(QMainWindow):
 
         self.view = View()
         self.view.loadRequested.connect(self.load)
+        self.view.reloadRequested.connect(self.reload)
         self.view.internalUrlClicked.connect(self.handleInternalUrl)
 
         self._findWidget = FindWidget(self.view)


### PR DESCRIPTION
- Refresh: the default implementation is broken as the refresh is done at the
  WebPage level and the converter is not aware.
  Here we call the same action and use the same wording as the menu.
- Copy: use the QWebPage implementation

![context](https://cloud.githubusercontent.com/assets/365097/17502111/1ba0c8a0-5d9a-11e6-9ad8-2bc618043a02.png)
